### PR TITLE
Unpin SystemUIGoogle that requires google services.

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -742,10 +742,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 else
 endif
 
-# Preopt SystemUI
-PRODUCT_DEXPREOPT_SPEED_APPS += \
-    SystemUIGoogle
-
 # Enable stats logging in LMKD
 TARGET_LMKD_STATS_LOG := true
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -339,8 +339,6 @@
         <item>"/system/framework/boot.vdex"</item>
         <item>"/system/framework/arm64/boot-core-libart.oat"</item>
         <item>"/system/framework/boot-core-libart.vdex"</item>
-        <item>"/system/priv-app/SystemUIGoogle/oat/arm64/SystemUIGoogle.vdex"</item>
-        <item>"/system/priv-app/SystemUIGoogle/oat/arm64/SystemUIGoogle.odex"</item>
         <item>"/system/lib64/libsurfaceflinger.so"</item>
     </string-array>
 


### PR DESCRIPTION
SystemUIGoogle requires SystemUIGoogle.apk and google services which might not be desirable by some the users.